### PR TITLE
Fix #4: Allow user to set null value to columns

### DIFF
--- a/src/DbFaker.SqlServer/SqlServerDialect.cs
+++ b/src/DbFaker.SqlServer/SqlServerDialect.cs
@@ -159,7 +159,7 @@ ORDER BY OUTCOLUMNS.column_id
                 {
                     Direction = System.Data.ParameterDirection.Input,
                     ParameterName = "@" + column,
-                    Value = values[column]
+                    Value = values[column] ?? DBNull.Value
                 });
             }
 


### PR DESCRIPTION
Allow user to set a null value to Nullable columns by properly using DBNull.Value.